### PR TITLE
Externalize relay database

### DIFF
--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -1,5 +1,7 @@
 FROM pypy:3.9-bullseye
 
+VOLUME /db
+
 COPY Pipfile /app/Pipfile
 COPY Pipfile.lock /app/Pipfile.lock
 
@@ -15,4 +17,4 @@ RUN pip install git+https://github.com/magic-wormhole/magic-wormhole-mailbox-ser
 COPY welcome.motd welcome.motd
 
 # --blur-usage=3600 Logging time rounded to 1 hour and turns off request-logging
-CMD twist wormhole-mailbox --blur-usage=3600 --motd "$(cat welcome.motd)"
+CMD twist wormhole-mailbox --channel-db=/db/relay.sqlite --blur-usage=3600 --motd "$(cat welcome.motd)"


### PR DESCRIPTION
We need to store the relay database outside the docker container to allow for smooth container updates and to follow best practice.