### PR TITLE
Fix set-output deprecation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,13 +28,13 @@ jobs:
         echo "github.ref: ${{ github.ref }}"
         echo "github.ref_type: ${{ github.ref_type }}"
         if [ ${{ github.ref_type }} == 'branch' ]; then
-        echo "::set-output name=target_tag::$(git rev-parse --short HEAD)"
+        echo "target_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         else
-        echo "::set-output name=target_tag::$(git describe --tags --always)"
+        echo "target_tag=$(git describe --tags --always)" >> $GITHUB_ENV
         fi
     - name: Build the Docker image
       working-directory: ./${{ matrix.target.directory }}
-      run: docker build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ steps.target.outputs.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }}
+      run: docker build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }}
     - name: List images
       run: docker images
     - name: Login to Docker Hub
@@ -44,10 +44,10 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     - name: Push to docker hub
-      run: docker push ${{ matrix.target.image }}:${{ steps.target.outputs.target_tag }}
+      run: docker push ${{ matrix.target.image }}:${{ env.target_tag }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     - name: Push to docker hub latest
       run: |
-        docker tag ${{ matrix.target.image }}:${{ steps.target.outputs.target_tag }} ${{ matrix.target.image }}:latest
+        docker tag ${{ matrix.target.image }}:${{ env.target_tag }} ${{ matrix.target.image }}:latest
         docker push ${{ matrix.target.image }}:latest
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'


### PR DESCRIPTION
According to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/  `set-output` directives in action defitions should be replaced.