### PR TITLE
Add arm64 support for docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,9 +36,11 @@ jobs:
         echo "target_tag=$(git describe --tags --always)" >> $GITHUB_ENV
         fi
         cat $GITHUB_ENV
+    - name: Create Builder
+      run: docker buildx create --name mwbuilder --bootstrap --use
     - name: Build the Docker image
       working-directory: ./${{ matrix.target.directory }}
-      run: docker build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }}
+      run: docker buildx build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }} --platform linux/arm64/v8,linux/amd64
     - name: List images
       run: docker images
     - name: Login to Docker Hub

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,12 +17,15 @@ jobs:
           - directory: mailbox
             image: leastauthority/magic-wormhole-mailbox
             version: ac91c3a
+            platforms: linux/arm64/v8,linux/amd64
           - directory: relay
             image: leastauthority/magic-wormhole-relay
             version: db48e91
+            platforms: linux/arm64/v8,linux/amd64
           - directory: wormhole
             image: leastauthority/magic-wormhole
             version: 52ee3ce
+            platforms: linux/arm64/v8,linux/amd64
     steps:
     - uses: actions/checkout@v3
     - name: Determine target tag
@@ -38,9 +41,9 @@ jobs:
         cat $GITHUB_ENV
     - name: Create Builder
       run: docker buildx create --name mwbuilder --bootstrap --use
-    - name: Build the Docker image
+    - name: Build the Docker image in cache
       working-directory: ./${{ matrix.target.directory }}
-      run: docker buildx build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }} --platform linux/arm64/v8,linux/amd64
+      run: docker buildx build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }} --platform ${{ matrix.target.platforms }}
     - name: List images
       run: docker images
     - name: Login to Docker Hub
@@ -49,11 +52,11 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-    - name: Push to docker hub
-      run: docker push ${{ matrix.target.image }}:${{ env.target_tag }}
+    - name: Push to Docker Hub
+      working-directory: ./${{ matrix.target.directory }}
+      run: docker buildx build --push . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }} --platform ${{ matrix.target.platforms }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-    - name: Push to docker hub latest
-      run: |
-        docker tag ${{ matrix.target.image }}:${{ env.target_tag }} ${{ matrix.target.image }}:latest
-        docker push ${{ matrix.target.image }}:latest
+    - name: Push to Docker Hub latest
+      working-directory: ./${{ matrix.target.directory }}
+      run: docker buildx build --push . --file Dockerfile --tag ${{ matrix.target.image }}:latest --build-arg VERSION_TAG=${{ matrix.target.version }} --platform ${{ matrix.target.platforms }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,7 +40,9 @@ jobs:
         fi
         cat $GITHUB_ENV
     - name: Create Builder
-      run: docker buildx create --name mwbuilder --bootstrap --use
+      run: | 
+        docker buildx create --name mwbuilder --bootstrap --use
+        docker buildx inspect mwbuilder
     - name: Build the Docker image in cache
       working-directory: ./${{ matrix.target.directory }}
       run: docker buildx build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }} --build-arg VERSION_TAG=${{ matrix.target.version }} --platform ${{ matrix.target.platforms }}


### PR DESCRIPTION
Based on issue https://github.com/LeastAuthority/magic-wormhole-docker/issues/14 adding arm64 support for docker images, that it would not be emulated on M1/M2 and similar ARM machines while running in docker.

Needed to switch to buildx for building multiplatform arch.
Guided by instruction: https://www.docker.com/blog/how-to-rapidly-build-multi-architecture-images-with-buildx/ 