### PR TITLE
Enable dependabot to patch base images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       interval: "daily"
       time: "12:00"
     reviewers:
-      - "LeastAuthority/it-ops"
+      - "LeastAuthority/magic-wormhole"
   - package-ecosystem: "docker"
     directory: "/relay"
     ignore:
@@ -19,7 +19,7 @@ updates:
       interval: "daily"
       time: "12:00"
     reviewers:
-      - "LeastAuthority/it-ops"
+      - "LeastAuthority/magic-wormhole"
   - package-ecosystem: "docker"
     directory: "/docker/mailbox"
     ignore:
@@ -29,4 +29,4 @@ updates:
       interval: "daily"
       time: "12:00"
     reviewers:
-      - "LeastAuthority/it-ops"
+      - "LeastAuthority/magic-wormhole"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/mailbox"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    schedule:
+      interval: "daily"
+      time: "12:00"
+    reviewers:
+      - "LeastAuthority/it-ops"
+  - package-ecosystem: "docker"
+    directory: "/relay"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    schedule:
+      interval: "daily"
+      time: "12:00"
+    reviewers:
+      - "LeastAuthority/it-ops"
+  - package-ecosystem: "docker"
+    directory: "/docker/mailbox"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    schedule:
+      interval: "daily"
+      time: "12:00"
+    reviewers:
+      - "LeastAuthority/it-ops"


### PR DESCRIPTION
Closes #27

This pull request enables Dependabot to track available patch for our 3 Docker base images.

Once merged, version [updates](https://github.com/LeastAuthority/magic-wormhole-docker/network/updates) should be enabled and automatically creates 2 pull request to bump `pypy:3.9-7.3.9-slim-bullseye` to `pypy:3.9-7.3.11-slim-bullseye`.