### PR TITLE
Add labels to source for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     reviewers:
       - "LeastAuthority/magic-wormhole"
   - package-ecosystem: "docker"
-    directory: "/docker/mailbox"
+    directory: "/wormhole"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -22,3 +22,8 @@ COPY welcome.motd welcome.motd
 
 # --blur-usage=3600 Logging time rounded to 1 hour and turns off request-logging
 CMD twist wormhole-mailbox --channel-db=/db/relay.sqlite --usage-db=/db/usage-relay.sqlite --blur-usage=3600 --motd "$(cat welcome.motd)"
+
+LABEL org.opencontainers.image.title="Magic Wormhole mailbox"
+LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole mailbox service"
+LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/mailbox"
+LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"

--- a/readme.adoc
+++ b/readme.adoc
@@ -25,7 +25,7 @@ Update the `requirements.in` file in selected target folder and replace the Git 
 
 [source]
 ----
-magic-wormhole-mailbox-server @ git+https://github.com/magic-wormhole/magic-wormhole-mailbox-server@4b358859ba80de37c3dc0a5f67ec36909fd48234#egg=magic-wormhole-mailbox-server
+magic-wormhole-mailbox-server @ https://github.com/magic-wormhole/magic-wormhole-mailbox-server@4b358859ba80de37c3dc0a5f67ec36909fd48234#egg=magic-wormhole-mailbox-server
 ----
 
 or just give the desired released version:

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -18,3 +18,8 @@ RUN pip install \
     -r requirements.txt
 
 CMD twist transitrelay --usage-db=/db/usage-transitrelay.sqlite --blur-usage 3600 --port=tcp:4001 --websocket=tcp:4002
+
+LABEL org.opencontainers.image.title="Magic Wormhole relay"
+LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole relay service"
+LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/relay"
+LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -16,3 +16,8 @@ RUN pip install \
     -r requirements.txt
 
 CMD wormhole
+
+LABEL org.opencontainers.image.title="Magic Wormhole CLI"
+LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole implementation and CLI"
+LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/wormhole"
+LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"


### PR DESCRIPTION
Refers to #33

This pull request add the labels as [recommended](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker) for Dependabot to find the source code.

In addition, the pull request also fix the documentation and the wrong path to the Dockerfile of the Wormhole CLI image.