### PR TITLE
Improve Dockerfiles

### DIFF
--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -1,29 +1,42 @@
 FROM pypy:3.9-7.3.11-slim-bullseye
 
 RUN apt-get update && apt-get install -y \
-    git rustc \
+    rustc \
     && rm -rf /var/lib/apt/lists/*
 
-VOLUME /db
-
-COPY requirements.txt /app/
-
-WORKDIR /app
-
-ARG VERSION_TAG
-RUN pip install \
-    --disable-pip-version-check \
-    --no-cache \
-    --upgrade \
-    -r requirements.txt
-
-# Copy welcome message as file to load with newlines symbols in parameters
-COPY welcome.motd welcome.motd
-
-# --blur-usage=3600 Logging time rounded to 1 hour and turns off request-logging
-CMD twist wormhole-mailbox --channel-db=/db/relay.sqlite --usage-db=/db/usage-relay.sqlite --blur-usage=3600 --motd "$(cat welcome.motd)"
-
+# Metadata
 LABEL org.opencontainers.image.title="Magic Wormhole mailbox"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole mailbox service"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/mailbox"
 LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+
+# Install the application
+COPY requirements.txt /app/
+
+RUN pip install \
+    --disable-pip-version-check \
+    --no-cache \
+    --upgrade \
+    -r /app/requirements.txt
+
+# Copy welcome message as file to load with newlines symbols in parameters
+# FIXME: This motd should not be shipped in this image (configured downstream)
+COPY welcome.motd /app/welcome.motd
+
+# Default parameters and command to start
+ENV MW_MAILBOX_BLUR_USAGE="3600"
+ENV MW_MAILBOX_PROTO="tcp"
+ENV MW_MAILBOX_PORT="4000"
+
+CMD twist wormhole-mailbox \
+    --channel-db="/db/relay.sqlite" \
+    --usage-db="/db/usage-relay.sqlite" \
+    --blur-usage="${MW_MAILBOX_BLUR_USAGE}" \
+    --port="${MW_MAILBOX_PROTO}:${MW_MAILBOX_PORT}" \
+    --motd "$(cat /app/welcome.motd)"
+
+# Persistent data
+VOLUME /db
+
+# Expose port
+EXPOSE "${MW_MAILBOX_PORT}/${MW_MAILBOX_PROTO}"

--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 LABEL org.opencontainers.image.title="Magic Wormhole mailbox"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole mailbox service"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/mailbox"
-LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+LABEL org.opencontainers.image.vendor="Least Authority TFA GmbH"
 
 # Install the application
 COPY requirements.txt /app/

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,25 +1,39 @@
 FROM pypy:3.9-7.3.11-slim-bullseye
 
 RUN apt-get update && apt-get install -y \
-    git rustc \
+    rustc \
     && rm -rf /var/lib/apt/lists/*
 
-VOLUME /db
-
-COPY requirements.txt /app/
-
-WORKDIR /app
-
-ARG VERSION_TAG
-RUN pip install \
-    --disable-pip-version-check \
-    --no-cache \
-    --upgrade \
-    -r requirements.txt
-
-CMD twist transitrelay --usage-db=/db/usage-transitrelay.sqlite --blur-usage 3600 --port=tcp:4001 --websocket=tcp:4002
-
+# Metadata
 LABEL org.opencontainers.image.title="Magic Wormhole relay"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole relay service"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/relay"
 LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+
+# Install the application
+COPY requirements.txt /app/
+
+RUN pip install \
+    --disable-pip-version-check \
+    --no-cache \
+    --upgrade \
+    -r /app/requirements.txt
+
+# Default parameters and command to start
+ENV MW_RELAY_BLUR_USAGE="3600"
+ENV MW_RELAY_PROTO="tcp"
+ENV MW_RELAY_PORT="4001"
+ENV MW_RELAY_WS_PROTO="tcp"
+ENV MW_RELAY_WS_PORT="4200"
+
+CMD twist transitrelay \
+    --usage-db="/db/usage-transitrelay.sqlite" \
+    --blur-usage="${MW_RELAY_BLUR_USAGE}" \
+    --port="${MW_RELAY_PROTO}:${MW_RELAY_PORT}" \
+    --websocket="${MW_RELAY_WS_PROTO}:${MW_RELAY_WS_PORT}"
+
+# Persistent data
+VOLUME /db
+
+# Expose ports
+EXPOSE "${MW_RELAY_PORT}/${MW_RELAY_PROTO}" "${MW_RELAY_WS_PORT}/${MW_RELAY_WS_PROTO}"

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 LABEL org.opencontainers.image.title="Magic Wormhole relay"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole relay service"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/relay"
-LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+LABEL org.opencontainers.image.vendor="Least Authority TFA GmbH"
 
 # Install the application
 COPY requirements.txt /app/

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -1,9 +1,6 @@
 # Pull official base image from DockerHub
 FROM python:3.9.16-slim-bullseye
 
-RUN apt-get update && apt-get install -y \
-    && rm -rf /var/lib/apt/lists/*
-
 # Metadata
 LABEL org.opencontainers.image.title="Magic Wormhole CLI"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole implementation and CLI"

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -4,20 +4,22 @@ FROM python:3.9.16-slim-bullseye
 RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /app/
-
-WORKDIR /app
-
-ARG VERSION_TAG
-RUN pip install \
-    --disable-pip-version-check \
-    --no-cache \
-    --upgrade \
-    -r requirements.txt
-
-CMD wormhole
-
+# Metadata
 LABEL org.opencontainers.image.title="Magic Wormhole CLI"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole implementation and CLI"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/wormhole"
 LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+
+# Install the application
+COPY requirements.txt /app/
+
+RUN pip install \
+    --disable-pip-version-check \
+    --no-cache \
+    --upgrade \
+    -r /app/requirements.txt
+
+# Default command to start the application
+CMD wormhole
+
+WORKDIR /app

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.9.16-slim-bullseye
 LABEL org.opencontainers.image.title="Magic Wormhole CLI"
 LABEL org.opencontainers.image.description="Docker image to run the Magic Wormhole implementation and CLI"
 LABEL org.opencontainers.image.source="https://github.com/LeastAuthority/magic-wormhole-docker/wormhole"
-LABEL org.opencontainers.image.vendor="LeastAuthority TFA GmbH"
+LABEL org.opencontainers.image.vendor="Least Authority TFA GmbH"
 
 # Install the application
 COPY requirements.txt /app/


### PR DESCRIPTION
Preparation for #34

* avoid git package - unused since #30
* re-order and document steps
* use environment variables as parameters
* expose ports

The goal of this PR is to rework the Dockerfile's before switching to rootless.