### PR TITLE
Test images with Docker Composer

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -87,12 +87,12 @@ jobs:
     - name: Push to docker hub
       run: |
         for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
-          docker push ${image}:${{ env.target_tag }}
+          docker push leastauthority/${image}:${{ env.target_tag }}
         done
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     - name: Push to docker hub latest
       run: |
         for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
-          docker push ${image}:latest
+          docker push leastauthority/${image}:latest
         done
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,7 +60,6 @@ jobs:
           docker-compose -f docker-compose-front.yml up --abort-on-container-exit || \
           { docker-compose -f docker-compose-back.yml logs;
             RET=1; }
-          docker-compose -f docker-compose-front.yml down
           docker-compose -f docker-compose-back.yml down
           exit ${RET:-0}
       - name: Determine target tag

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,9 +32,8 @@ jobs:
       - name: Build images
         id: build_images
         run: |
-          # Only if not kust restored from the cache
-          repository=${{ github.repository }}
-          if [ $(docker images --quiet ${repository##*/}_magic-wormhole*:latest | wc -l) -lt 3 ]; then
+          # Only if not just restored from the cache
+          if [ $(docker images --quiet leastauthority/magic-wormhole*:latest | wc -l) -lt 3 ]; then
             docker-compose -f docker-compose-back.yml build --progress=plain
             docker-compose -f docker-compose-front.yml build --progress=plain
           fi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,14 +35,16 @@ jobs:
           docker-compose -f docker-compose-back.yml up --detach
           # Wait for the server
           for try in {1..3}; do
-            nc -w 3 127.0.0.1 ${MW_MAILBOX_PORT} > /dev/null 2>&1 && break || { sleep 1; }
-            nc -w 3 127.0.0.1 ${MW_RELAY_PORT} > /dev/null 2>&1 && break || { sleep 1; }
-            nc -w 3 127.0.0.1 ${MW_RELAY_WS_PORT} > /dev/null 2>&1 && break || { sleep 1; }
+            { nc -w 3 127.0.0.1 ${MW_MAILBOX_PORT} > /dev/null 2>&1 && \
+              nc -w 3 127.0.0.1 ${MW_RELAY_PORT} > /dev/null 2>&1 && \
+              nc -w 3 127.0.0.1 ${MW_RELAY_WS_PORT} > /dev/null 2>&1; \
+            } && break || { sleep 1; }
             if [ $try = 3 ]; then
               echo ":x: Back-end services failed to start" >> $GITHUB_STEP_SUMMARY;
               exit 1
             fi
           done
+          docker-compose -f docker-compose-back.yml ps
           docker-compose -f docker-compose-front.yml up --abort-on-container-exit
           docker-compose -f docker-compose-back.yml down
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,8 +57,12 @@ jobs:
             fi
           done
           docker-compose -f docker-compose-back.yml ps
-          docker-compose -f docker-compose-front.yml up --abort-on-container-exit
+          docker-compose -f docker-compose-front.yml up --abort-on-container-exit || \
+          { docker-compose -f docker-compose-back.yml logs;
+            RET=1; }
+          docker-compose -f docker-compose-front.yml down
           docker-compose -f docker-compose-back.yml down
+          exit ${RET:-0}
       - name: Determine target tag
         id: target
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,8 +9,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test:
-    name: Test
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,21 +59,6 @@ jobs:
           docker-compose -f docker-compose-back.yml ps
           docker-compose -f docker-compose-front.yml up --abort-on-container-exit
           docker-compose -f docker-compose-back.yml down
-  build:
-    name: Build
-    needs: test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - directory: mailbox
-            image: leastauthority/magic-wormhole-mailbox
-          - directory: relay
-            image: leastauthority/magic-wormhole-relay
-          - directory: wormhole
-            image: leastauthority/magic-wormhole
-    steps:
-    - uses: actions/checkout@v3
     - name: Determine target tag
       id: target
       run: |
@@ -85,9 +70,12 @@ jobs:
         echo "target_tag=$(git describe --tags --always)" >> $GITHUB_ENV
         fi
         cat $GITHUB_ENV
-    - name: Build the Docker image
-      working-directory: ./${{ matrix.target.directory }}
-      run: docker build . --file Dockerfile --tag ${{ matrix.target.image }}:${{ env.target_tag }}
+    - name: Tag images
+      id: tag_images
+      run: |
+        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+          docker tag leastauthority/${image}:latest leastauthority/${image}:${{ env.target_tag }}
+        done
     - name: List images
       run: docker images
     - name: Login to Docker Hub
@@ -97,10 +85,14 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     - name: Push to docker hub
-      run: docker push ${{ matrix.target.image }}:${{ env.target_tag }}
+      run: |
+        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+          docker push ${image}:${{ env.target_tag }}
+        done
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     - name: Push to docker hub latest
       run: |
-        docker tag ${{ matrix.target.image }}:${{ env.target_tag }} ${{ matrix.target.image }}:latest
-        docker push ${{ matrix.target.image }}:latest
+        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+          docker push ${image}:latest
+        done
       if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,8 +27,22 @@ jobs:
           docker-compose -f docker-compose-front.yml build --progress=plain
       - name: Test images
         id: test_images
+        env:
+          MW_MAILBOX_PORT: 4000
+          MW_RELAY_PORT: 4001
+          MW_RELAY_WS_PORT: 4200
         run: |
           docker-compose -f docker-compose-back.yml up --detach
+          # Wait for the server
+          for try in {1..3}; do
+            nc -w 3 127.0.0.1 ${MW_MAILBOX_PORT} > /dev/null 2>&1 && break || { sleep 1; }
+            nc -w 3 127.0.0.1 ${MW_RELAY_PORT} > /dev/null 2>&1 && break || { sleep 1; }
+            nc -w 3 127.0.0.1 ${MW_RELAY_WS_PORT} > /dev/null 2>&1 && break || { sleep 1; }
+            if [ $try = 3 ]; then
+              echo ":x: Back-end services failed to start" >> $GITHUB_STEP_SUMMARY;
+              exit 1
+            fi
+          done
           docker-compose -f docker-compose-front.yml up --abort-on-container-exit
           docker-compose -f docker-compose-back.yml down
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           sudo apt install --quiet docker-compose
           docker run hello-world
-      - name: Cache docker images
+      - name: Cache images
         uses: ScribeMD/docker-cache@0.3.3
         with:
           key: |
@@ -77,7 +77,9 @@ jobs:
             docker tag leastauthority/${image}:latest leastauthority/${image}:${{ env.target_tag }}
           done
       - name: List images
-        run: docker images
+        id: list_images
+        run: |
+          docker images leastauthority/magic-wormhole*:*
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  whynot:
+  build:
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -59,40 +59,40 @@ jobs:
           docker-compose -f docker-compose-back.yml ps
           docker-compose -f docker-compose-front.yml up --abort-on-container-exit
           docker-compose -f docker-compose-back.yml down
-    - name: Determine target tag
-      id: target
-      run: |
-        echo "github.ref: ${{ github.ref }}"
-        echo "github.ref_type: ${{ github.ref_type }}"
-        if [ ${{ github.ref_type }} == 'branch' ]; then
-        echo "target_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-        else
-        echo "target_tag=$(git describe --tags --always)" >> $GITHUB_ENV
-        fi
-        cat $GITHUB_ENV
-    - name: Tag images
-      id: tag_images
-      run: |
-        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
-          docker tag leastauthority/${image}:latest leastauthority/${image}:${{ env.target_tag }}
-        done
-    - name: List images
-      run: docker images
-    - name: Login to Docker Hub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-    - name: Push to docker hub
-      run: |
-        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
-          docker push leastauthority/${image}:${{ env.target_tag }}
-        done
-      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
-    - name: Push to docker hub latest
-      run: |
-        for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
-          docker push leastauthority/${image}:latest
-        done
-      if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+      - name: Determine target tag
+        id: target
+        run: |
+          echo "github.ref: ${{ github.ref }}"
+          echo "github.ref_type: ${{ github.ref_type }}"
+          if [ ${{ github.ref_type }} == 'branch' ]; then
+          echo "target_tag=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          else
+          echo "target_tag=$(git describe --tags --always)" >> $GITHUB_ENV
+          fi
+          cat $GITHUB_ENV
+      - name: Tag images
+        id: tag_images
+        run: |
+          for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+            docker tag leastauthority/${image}:latest leastauthority/${image}:${{ env.target_tag }}
+          done
+      - name: List images
+        run: docker images
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+      - name: Push to docker hub
+        run: |
+          for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+            docker push leastauthority/${image}:${{ env.target_tag }}
+          done
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
+      - name: Push to docker hub latest
+        run: |
+          for image in magic-wormhole-mailbox magic-wormhole-relay magic-wormhole; do
+            docker push leastauthority/${image}:latest
+          done
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,7 +29,7 @@ jobs:
         id: test_images
         run: |
           docker-compose -f docker-compose-back.yml up --detach
-          docker-compose -f docker-compose-front.yml up
+          docker-compose -f docker-compose-front.yml up --abort-on-container-exit
           docker-compose -f docker-compose-back.yml down
   build:
     name: Build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  whynot:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,31 @@ on:
     branches: [ "main" ]
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install docker support
+        id: install_docker
+        run: |
+          sudo apt install --quiet docker-compose
+          docker run hello-world
+      - name: Build images
+        id: build_images
+        run: |
+          docker-compose -f docker-compose-back.yml build --progress=plain
+          docker-compose -f docker-compose-front.yml build --progress=plain
+      - name: Test images
+        id: test_images
+        run: |
+          docker-compose -f docker-compose-back.yml up --detach
+          docker-compose -f docker-compose-front.yml up
+          docker-compose -f docker-compose-back.yml down
   build:
+    name: Build
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,11 +20,24 @@ jobs:
         run: |
           sudo apt install --quiet docker-compose
           docker run hello-world
+      - name: Cache docker images
+        uses: ScribeMD/docker-cache@0.3.3
+        with:
+          key: |
+            docker-${{ runner.os }}-${{ hashFiles(
+              '**/docker-compose*.yml',
+              '**/*Dockerfile*',
+              '**/requirements.*'
+            ) }}
       - name: Build images
         id: build_images
         run: |
-          docker-compose -f docker-compose-back.yml build --progress=plain
-          docker-compose -f docker-compose-front.yml build --progress=plain
+          # Only if not kust restored from the cache
+          repository=${{ github.repository }}
+          if [ $(docker images --quiet ${repository##*/}_magic-wormhole*:latest | wc -l) -lt 3 ]; then
+            docker-compose -f docker-compose-back.yml build --progress=plain
+            docker-compose -f docker-compose-front.yml build --progress=plain
+          fi
       - name: Test images
         id: test_images
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+/.env*
+/*_database

--- a/docker-compose-back.yml
+++ b/docker-compose-back.yml
@@ -8,6 +8,8 @@ services:
       - MW_MAILBOX_PORT=${MW_MAILBOX_PORT:-4000}
     volumes:
       - "./mailbox_database:/db"
+    ports:
+      - ${MW_MAILBOX_PORT:-4000}:${MW_MAILBOX_PORT:-4000}
   relay:
     image: leastauthority/magic-wormhole-relay
     build:
@@ -17,3 +19,6 @@ services:
       - MW_RELAY_WS_PORT=${MW_RELAY_WS_PORT:-4200}
     volumes:
       - "./relay_database:/db"
+    ports:
+      - ${MW_RELAY_PORT:-4001}:${MW_RELAY_PORT:-4001}
+      - ${MW_RELAY_WS_PORT:-4200}:${MW_RELAY_WS_PORT:-4200}

--- a/docker-compose-back.yml
+++ b/docker-compose-back.yml
@@ -1,0 +1,19 @@
+version: "3.3"
+services:
+  mailbox:
+    image: leastauthority/magic-wormhole-mailbox
+    build:
+      context: ./mailbox
+    environment:
+      - MW_MAILBOX_PORT=${MW_MAILBOX_PORT:-4000}
+    volumes:
+      - "./mailbox_database:/db"
+  relay:
+    image: leastauthority/magic-wormhole-relay
+    build:
+      context: ./relay
+    environment:
+      - MW_RELAY_PORT=${MW_RELAY_PORT:-4001}
+      - MW_RELAY_WS_PORT=${MW_RELAY_WS_PORT:-4200}
+    volumes:
+      - "./relay_database:/db"

--- a/docker-compose-front.yml
+++ b/docker-compose-front.yml
@@ -1,0 +1,12 @@
+version: "3.3"
+services:
+  sender:
+    image: leastauthority/magic-wormhole
+    build:
+      context: ./wormhole
+    command: wormhole --relay-url="ws://mailbox:${MW_MAILBOX_PORT:-4000}/v1" --transit-helper="tcp://relay:${MW_RELAY_PORT:-4001}" send --hide-progress --code 1-special-code --text "Hello world!"
+  receiver:
+    image: leastauthority/magic-wormhole
+    build:
+      context: ./wormhole
+    command: wormhole --relay-url="ws://mailbox:${MW_MAILBOX_PORT:-4000}/v1" --transit-helper="tcp://relay:${MW_RELAY_PORT:-4001}" receive --hide-progress --only-text 1-special-code

--- a/readme.adoc
+++ b/readme.adoc
@@ -17,6 +17,28 @@ The 2 first images are currently used in the magic-wormhole backend operated by 
 * Winden https://winden.app/ (see https://github.com/LeastAuthority/winden)
 * Destiny (see https://github.com/LeastAuthority/destiny)
 
+== Integration test
+
+This repository provides Docker Composer files to build and test the images.
+The test is basic: send and receive "Hello world!" message through a local wormhole.
+
+[source]
+----
+# Build the back-end images
+docker compose -f docker-compose-back.yml build
+# Build the front-end images
+docker compose -f docker-compose-front.yml build
+# Start the back-end in the background
+docker compose -f docker-compose-back.yml up --detach
+# Start the front-end in the foreground
+docker compose -f docker-compose-front.yml up
+# Stop the back-end (or replay the previous step)
+docker compose -f docker-compose-back.yml down
+----
+
+REM: Use `docker-compose` for older version.
+
+
 == Basic instructions
 
 === Select which source versions to use for the build


### PR DESCRIPTION
Closes #41

This PR adds a basic system test which might be helpful for local dev. too (see documentation).

To achieve this test, the matrix strategy had to be replaced by a single job building all images.
In addition, this PR also introduce some caching to speedup builds when the relevant "Docker" files have not been changed.