### PR TITLE
Bump python from 3.9 to 3.10 now from bookworm

### DIFF
--- a/mailbox/Dockerfile
+++ b/mailbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:3.9-7.3.16-slim-bullseye
+FROM pypy:3.10-7.3.19-slim-bookworm@sha256:5d18aa0232059c991ff8d52f1b528a6ff8f55c86154ba248a270a6eb90975f3a
 
 RUN apt-get update && apt-get install -y \
     rustc \

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:3.9-7.3.16-slim-bullseye
+FROM pypy:3.10-7.3.19-slim-bookworm@sha256:5d18aa0232059c991ff8d52f1b528a6ff8f55c86154ba248a270a6eb90975f3a
 
 RUN apt-get update && apt-get install -y \
     rustc \

--- a/wormhole/Dockerfile
+++ b/wormhole/Dockerfile
@@ -1,5 +1,5 @@
 # Pull official base image from DockerHub
-FROM python:3.9.23-slim-bullseye
+FROM python:3.10.18-slim-bookworm@sha256:66a6e8a211a02794515d4e1aa1970fc037ec4dde1429395e1321bdd63af01256
 
 # Metadata
 LABEL org.opencontainers.image.title="Magic Wormhole CLI"


### PR DESCRIPTION
Part of LeastAuthority/it-ops#323

Upgrade Python to 3.10 and pin container base images by hash digest for immutability