### PR TITLE
Rollback the relay websocket port from 4200 to 4002 as before #40

### DIFF
--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -49,7 +49,7 @@ ENV MW_RELAY_BLUR_USAGE="3600"
 ENV MW_RELAY_PROTO="tcp"
 ENV MW_RELAY_PORT="4001"
 ENV MW_RELAY_WS_PROTO="tcp"
-ENV MW_RELAY_WS_PORT="4200"
+ENV MW_RELAY_WS_PORT="4002"
 
 CMD twist transitrelay \
     --usage-db="/db/usage-transitrelay.sqlite" \


### PR DESCRIPTION
Since #40, the websocket pour of the relay has been changed to 4200.
This change rolls it back to its initial value which was 4002.